### PR TITLE
Fix use of --isolate and --careful options on spades restart

### DIFF
--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -243,8 +243,8 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
         command += ['--restart-from', f'k{previous_k}']
         # make sure these options are not added again to the command line
         # when restarting from previous run as this would lead SPAdes to crash
-        split_spades_options.remove('--careful')
-        split_spades_options.remove('--isolate')
+        if '--careful' in split_spades_options: split_spades_options.remove('--careful')
+        if '--isolate' in split_spades_options: split_spades_options.remove('--isolate')
     if spades_options:
         command += split_spades_options
     if not spades_options or '-m' not in split_spades_options:

--- a/unicycler/spades_func.py
+++ b/unicycler/spades_func.py
@@ -230,8 +230,10 @@ def build_spades_command(spades_path, spades_dir, threads, kmers, i, short1, sho
             if '--isolate' in split_spades_options:
                 raise ValueError("SPAdes options '--careful' and '--isolate' are not compatible; please choose one or the other")
             command += ['--careful']
+            split_spades_options.remove('--careful')
         elif '--isolate' in split_spades_options:
             command += ['--isolate']
+            split_spades_options.remove('--isolate')
         if using_paired_reads:
             command += ['-1', short1, '-2', short2]
         if using_unpaired_reads:


### PR DESCRIPTION
see https://gitlab.internal.sanger.ac.uk/sanger-pathogens/docker-images/-/merge_requests/471
tests of current main fail when using `--spades_options "--isolate"` with or without other spades options passed on.

while no specific error is raised by `spades.py`, it seems not to like being given the `--isolate` option on the second round of assembly restarting from the precomputed data of first round - a behaviour that would not have happened in the original Unicycler.
```
[fl4@farm22-head2 test_unicycler]$ less mode_bold_spades_options_isolate_/unicycler.log
spades.py -o
```
```
/lustre/scratch126/pam/teams/team230/fl4/test_unicycler/mode_bold_spades_options_isolate_/spades_assembly -k 27 --threads 4 --gfa11 --isolate -1 /lustre/scratch126/p
am/teams/team230/fl4/test_unicycler/SAMN24018632_1.fastq.gz -2 /lustre/scratch126/pam/teams/team230/fl4/test_unicycler/SAMN24018632_2.fastq.gz -m 1024
spades.py -o /lustre/scratch126/pam/teams/team230/fl4/test_unicycler/mode_bold_spades_options_isolate_/spades_assembly -k 27,53 --threads 4 --gfa11 --restart-from k27 --isolate -
m 1024
Error: SPAdes encountered an error:

```
so need to condition the passing of the `--isolate` option to spades being on the first round only.

Question: should we apply this logic to the `--careful` option, while no error was reported with the current behaviour i.e. to pass the option again on 2nd+ round. The risk of not passing it again is that it's not used on those later rounds.
